### PR TITLE
Trigger e2e tests action after Vercel deploy is ready

### DIFF
--- a/.github/workflows/playwright-after.yml
+++ b/.github/workflows/playwright-after.yml
@@ -3,14 +3,34 @@ name: Playwright Tests By Vercel
 on:
   deployment_status:
 jobs:
-  run-e2es:
+  test_setup:
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
+    name: Test setup
+    runs-on: ubuntu-latest
+    outputs:
+      preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
+    steps:
+      - name: Wait for Vercel Preview
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.1    
+        id: waitForVercelPreviewDeployment
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 300
+  run-e2es:
+    name: Run e2e tests
+    needs: test_setup
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success'
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: npm ci && npx playwright install --with-deps
+      - name: Prepare testing env
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - run: npm ci
+      - run: npx playwright install --with-deps
       - name: Run tests
-        run: npx playwright test
+        run: npm run test:e2e
         env:
-          BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ needs.test_setup.outputs.preview_url }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Digitalent job board  
 
-[Demo](https://digitalentjobs.netlify.app/)
+[Demo](https://digitalentjobs.netlify.app/) 
 
 ## To run the project:
 


### PR DESCRIPTION
Trigerring the e2e action after Vercel deploy is ready saves action minutes. Before, the action was triggered on pull request and waited for the deploy. This change results in half the action time.